### PR TITLE
Disable okbuck plugin by default when not in use.

### DIFF
--- a/mobile_app1/build.gradle
+++ b/mobile_app1/build.gradle
@@ -27,4 +27,7 @@ buildScan {
     termsOfServiceAgree = 'yes'
     link 'GitHub', 'https://github.com/uber-common/android-build-eval'
 }
-apply plugin: 'com.uber.okbuck'
+// Only apply the okbuck Gradle plugin when generating the wrapper and BUCK files.
+if ((providers.systemProperty('okbuck.wrapper').forUseAtConfigurationTime().orNull ?: 'false').toBoolean()) {
+    apply plugin: 'com.uber.okbuck'
+}


### PR DESCRIPTION
Here is a build scan showing it is adding 372ms to the configuration time: https://scans.gradle.com/s/6uhqniof6bxzs/performance/configuration?openScriptsAndPlugins=WyJjb2RlLXVuaXQtY29tLnViZXIub2tidWNrIiwiY29kZS11bml0LWJ1aWxkLmdyYWRsZSJd#code-unit-com.uber.okbuck