### PR TITLE
Remove compile configuration references

### DIFF
--- a/mobile_app1/leafModuleMax/build.gradle
+++ b/mobile_app1/leafModuleMax/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "org.checkerframework:checker-compat-qual:2.5.5"
 }

--- a/mobile_app1/module1002/build.gradle
+++ b/mobile_app1/module1002/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"

--- a/mobile_app1/module1021/build.gradle
+++ b/mobile_app1/module1021/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module1066/build.gradle
+++ b/mobile_app1/module1066/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':module99')
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module1103/build.gradle
+++ b/mobile_app1/module1103/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "androidx.annotation:annotation-experimental:1.0.0"

--- a/mobile_app1/module112/build.gradle
+++ b/mobile_app1/module112/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module1139/build.gradle
+++ b/mobile_app1/module1139/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':module23')
     implementation project(':leafModuleMax')

--- a/mobile_app1/module1150/build.gradle
+++ b/mobile_app1/module1150/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':module319')
     implementation project(':leafModuleMax')
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module116/build.gradle
+++ b/mobile_app1/module116/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/mobile_app1/module1208/build.gradle
+++ b/mobile_app1/module1208/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':leafModuleMax')
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module1216/build.gradle
+++ b/mobile_app1/module1216/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':module353')
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module1221/build.gradle
+++ b/mobile_app1/module1221/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "io.grpc:grpc-api:1.23.0"
 }
 sourceCompatibility = "1.8"

--- a/mobile_app1/module123/build.gradle
+++ b/mobile_app1/module123/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.checkerframework:checker-compat-qual:2.5.5"
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module1259/build.gradle
+++ b/mobile_app1/module1259/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/mobile_app1/module1266/build.gradle
+++ b/mobile_app1/module1266/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module157/build.gradle
+++ b/mobile_app1/module157/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module160/build.gradle
+++ b/mobile_app1/module160/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "androidx.annotation:annotation-experimental:1.0.0"

--- a/mobile_app1/module184/build.gradle
+++ b/mobile_app1/module184/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "org.jetbrains.intellij.deps:trove4j:1.0.20181211"
     implementation project(':module443')

--- a/mobile_app1/module23/build.gradle
+++ b/mobile_app1/module23/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module252/build.gradle
+++ b/mobile_app1/module252/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
     implementation project(':module112')

--- a/mobile_app1/module26/build.gradle
+++ b/mobile_app1/module26/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "androidx.annotation:annotation-experimental:1.0.0"

--- a/mobile_app1/module288/build.gradle
+++ b/mobile_app1/module288/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.checkerframework:checker-compat-qual:2.5.5"
 }
 sourceCompatibility = "1.8"

--- a/mobile_app1/module298/build.gradle
+++ b/mobile_app1/module298/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module319/build.gradle
+++ b/mobile_app1/module319/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':leafModuleMax')
     implementation "org.checkerframework:checker-compat-qual:2.5.5"
     implementation "org.reactivestreams:reactive-streams:1.0.2"

--- a/mobile_app1/module33/build.gradle
+++ b/mobile_app1/module33/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':leafModuleMax')
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "org.jetbrains.intellij.deps:trove4j:1.0.20181211"

--- a/mobile_app1/module353/build.gradle
+++ b/mobile_app1/module353/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module410/build.gradle
+++ b/mobile_app1/module410/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
     implementation project(':module438')

--- a/mobile_app1/module422/build.gradle
+++ b/mobile_app1/module422/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "org.checkerframework:checker-compat-qual:2.5.5"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module430/build.gradle
+++ b/mobile_app1/module430/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "com.squareup.retrofit2:adapter-rxjava:2.6.0"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module438/build.gradle
+++ b/mobile_app1/module438/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
     implementation "com.squareup.okio:okio:2.7.0"

--- a/mobile_app1/module443/build.gradle
+++ b/mobile_app1/module443/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "org.jetbrains.intellij.deps:trove4j:1.0.20181211"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module444/build.gradle
+++ b/mobile_app1/module444/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':leafModuleMax')
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':module33')

--- a/mobile_app1/module46/build.gradle
+++ b/mobile_app1/module46/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
     implementation project(':module252')

--- a/mobile_app1/module464/build.gradle
+++ b/mobile_app1/module464/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }

--- a/mobile_app1/module477/build.gradle
+++ b/mobile_app1/module477/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module491/build.gradle
+++ b/mobile_app1/module491/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':module1066')
     implementation "com.squareup.okio:okio:2.7.0"
     implementation "com.squareup.moshi:moshi-adapters:1.10.0"

--- a/mobile_app1/module547/build.gradle
+++ b/mobile_app1/module547/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "org.checkerframework:checker-compat-qual:2.5.5"
 }

--- a/mobile_app1/module607/build.gradle
+++ b/mobile_app1/module607/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/mobile_app1/module628/build.gradle
+++ b/mobile_app1/module628/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module657/build.gradle
+++ b/mobile_app1/module657/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/mobile_app1/module66/build.gradle
+++ b/mobile_app1/module66/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "org.checkerframework:checker-compat-qual:2.5.5"

--- a/mobile_app1/module682/build.gradle
+++ b/mobile_app1/module682/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':leafModuleMax')
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "androidx.annotation:annotation-experimental:1.0.0"

--- a/mobile_app1/module752/build.gradle
+++ b/mobile_app1/module752/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/mobile_app1/module785/build.gradle
+++ b/mobile_app1/module785/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':module438')
     implementation "androidx.annotation:annotation-experimental:1.0.0"

--- a/mobile_app1/module788/build.gradle
+++ b/mobile_app1/module788/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
     implementation "com.squareup.retrofit2:adapter-rxjava:2.6.0"

--- a/mobile_app1/module80/build.gradle
+++ b/mobile_app1/module80/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
 }
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/mobile_app1/module850/build.gradle
+++ b/mobile_app1/module850/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "org.checkerframework:checker-compat-qual:2.5.5"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module872/build.gradle
+++ b/mobile_app1/module872/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
 }
 sourceCompatibility = "1.8"

--- a/mobile_app1/module88/build.gradle
+++ b/mobile_app1/module88/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
     implementation "androidx.annotation:annotation-experimental:1.0.0"

--- a/mobile_app1/module880/build.gradle
+++ b/mobile_app1/module880/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation project(':leafModuleMax')
     implementation "com.squareup.okio:okio:2.7.0"

--- a/mobile_app1/module891/build.gradle
+++ b/mobile_app1/module891/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
     implementation "androidx.annotation:annotation-experimental:1.0.0"

--- a/mobile_app1/module927/build.gradle
+++ b/mobile_app1/module927/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-allopen:1.4.21"
     implementation "androidx.annotation:annotation-experimental:1.0.0"
     implementation project(':leafModuleMax')

--- a/mobile_app1/module99/build.gradle
+++ b/mobile_app1/module99/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java-library'
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.checkerframework:checker-compat-qual:2.5.5"
 }
 sourceCompatibility = "1.8"


### PR DESCRIPTION
The compile configuration goes away in Gradle 7.0. Moreover, the references where to `compile fileTree(dir: 'libs', include: ['*.jar'])`, some libs directories which did not even exist.

I suppose the project generator configuration would need to be adjusted, so when regenerating the project then the `compile` dependencies will not be added again.